### PR TITLE
feat(vue): make previewed component visible in vue-devtools

### DIFF
--- a/packages/@birdseye/vue/test/wrap.spec.ts
+++ b/packages/@birdseye/vue/test/wrap.spec.ts
@@ -216,7 +216,7 @@ describe('Wrap', () => {
     expect(wrapper.find('#baz').text()).toBe('baz')
   })
 
-  it('can be injected Vue constructor', () => {
+  it('can be injected Vue constructor', async () => {
     const localVue = createLocalVue()
     localVue.prototype.$test = 'injected'
 
@@ -236,10 +236,13 @@ describe('Wrap', () => {
         data: {}
       }
     })
+
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.text()).toBe('injected')
   })
 
-  it('can be injected root constructor options', () => {
+  it('can be injected root constructor options', async () => {
     const { wrap } = createInstrument(Vue, {
       test: 'injected'
     } as any)
@@ -258,10 +261,13 @@ describe('Wrap', () => {
         data: {}
       }
     })
+
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.text()).toBe('injected')
   })
 
-  it('fills props value from meta default value', () => {
+  it('fills props value from meta default value', async () => {
     const Test = Vue.extend({
       props: {
         foo: {
@@ -283,10 +289,12 @@ describe('Wrap', () => {
       propsData: { props: {}, data: {} }
     })
 
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.text()).toBe('test1')
   })
 
-  it('fills props value from meta type', () => {
+  it('fills props value from meta type', async () => {
     const Test = Vue.extend({
       props: {
         foo: Number
@@ -305,10 +313,12 @@ describe('Wrap', () => {
       propsData: { props: {}, data: {} }
     })
 
+    await wrapper.vm.$nextTick()
+
     expect(wrapper.text()).toBe('0')
   })
 
-  it('does not overwrite specified props with default value', () => {
+  it('does not overwrite specified props with default value', async () => {
     const Test = Vue.extend({
       props: {
         foo: {
@@ -331,6 +341,8 @@ describe('Wrap', () => {
         data: {}
       }
     })
+
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.text()).toBe('foo')
   })


### PR DESCRIPTION
fix #8 

To let vue-devtools detect previewed component, we need to implement wrapper component a bit hacky way.

vue-devtools walks DOM elements just after the extension is initialized. We need to have an mounted element of vue instance to allow vue-devtools detect it. In addtion, the mounted element cannot be in other vue component because vue-devtools stops walking child elements when it is a mounted DOM element.

So we have to put mounted element just under the body element until vue-devtools detects it. I have put placeholder comment node and assign root vue instance to it because it is impossible to know when vue-devtools finished the initialization or it is not actually installed on browser.

