### PR TITLE
chore(app): add input field components for primitive values

### DIFF
--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -3,7 +3,7 @@
     <component
       :is="componentForType"
       :value="value"
-      @input="$emit('input', ...arguments)"
+      @input="$emit('input', arguments[0])"
     />
     <select
       class="select-type"

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="base-input">
+    <component
+      :is="componentForType"
+      :value="value"
+      @input="$emit('input', ...arguments)"
+    />
+    <select
+      class="select-type"
+      :value="typeOfValue"
+      @change="$emit('change-type', $event.target.value)"
+    >
+      <option
+        v-for="t in availableTypes"
+        :key="t"
+        :value="t"
+      >{{ t }}</option>
+    </select>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import InputString from './InputString.vue'
+
+const typeToComponentName: Record<string, string> = {
+  string: 'InputString'
+}
+
+const possibleTypes = Object.keys(typeToComponentName)
+
+export default Vue.extend({
+  name: 'BaseInput',
+
+  components: {
+    InputString
+  },
+
+  props: {
+    value: {
+      type: [String, Number, Boolean, Array, Object],
+      default: undefined
+    },
+
+    availableTypes: {
+      type: Array as () => string[],
+      required: true,
+      validator(types: string[]) {
+        return types.every(type => possibleTypes.indexOf(type) >= 0)
+      }
+    }
+  },
+
+  computed: {
+    typeOfValue(): string {
+      if (Array.isArray(this.value)) {
+        return 'array'
+      }
+
+      if (this.value && typeof this.value === 'object') {
+        return 'object'
+      }
+
+      return typeof this.value
+    },
+
+    componentForType(): string {
+      return typeToComponentName[this.typeOfValue]
+    }
+  }
+})
+</script>
+
+<birdseye lang="yml">
+name: BaseInput
+patterns:
+  - name: String
+    props:
+      value: string value
+      availableTypes:
+        - string
+</birdseye>

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -11,7 +11,7 @@
       @change="$emit('change-type', $event.target.value)"
     >
       <option
-        v-for="t in availableTypes"
+        v-for="t in realAvailableTypes"
         :key="t"
         :value="t"
       >{{ t }}</option>
@@ -50,7 +50,7 @@ export default Vue.extend({
 
     availableTypes: {
       type: Array as () => string[],
-      default: () => possibleTypes,
+      default: () => [],
       validator(types: string[]) {
         return types.every(type => possibleTypes.indexOf(type) >= 0)
       }
@@ -58,6 +58,15 @@ export default Vue.extend({
   },
 
   computed: {
+    /**
+     * Replace empty array to possibleTypes
+     */
+    realAvailableTypes(): string[] {
+      return this.availableTypes.length === 0
+        ? possibleTypes
+        : this.availableTypes
+    },
+
     typeOfValue(): string {
       if (Array.isArray(this.value)) {
         return 'array'

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -50,7 +50,7 @@ export default Vue.extend({
 
     availableTypes: {
       type: Array as () => string[],
-      required: true,
+      default: () => possibleTypes,
       validator(types: string[]) {
         return types.every(type => possibleTypes.indexOf(type) >= 0)
       }

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -92,16 +92,10 @@ patterns:
   - name: String
     props:
       value: string value
-      availableTypes:
-        - string
   - name: Number
     props:
       value: 123
-      availableTypes:
-        - number
   - name: Boolean
     props:
       value: true
-      availableTypes:
-        - boolean
 </birdseye>

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -23,10 +23,12 @@
 import Vue from 'vue'
 import InputString from './InputString.vue'
 import InputNumber from './InputNumber.vue'
+import InputBoolean from './InputBoolean.vue'
 
 const typeToComponentName: Record<string, string> = {
   string: 'InputString',
-  number: 'InputNumber'
+  number: 'InputNumber',
+  boolean: 'InputBoolean'
 }
 
 const possibleTypes = Object.keys(typeToComponentName)
@@ -36,7 +38,8 @@ export default Vue.extend({
 
   components: {
     InputString,
-    InputNumber
+    InputNumber,
+    InputBoolean
   },
 
   props: {
@@ -87,4 +90,9 @@ patterns:
       value: 123
       availableTypes:
         - number
+  - name: Boolean
+    props:
+      value: true
+      availableTypes:
+        - boolean
 </birdseye>

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -6,8 +6,8 @@
       @input="$emit('input', arguments[0])"
     />
     <select
-      class="select-type"
       :value="typeOfValue"
+      class="select-type"
       @change="$emit('change-type', $event.target.value)"
     >
       <option

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -22,9 +22,11 @@
 <script lang="ts">
 import Vue from 'vue'
 import InputString from './InputString.vue'
+import InputNumber from './InputNumber.vue'
 
 const typeToComponentName: Record<string, string> = {
-  string: 'InputString'
+  string: 'InputString',
+  number: 'InputNumber'
 }
 
 const possibleTypes = Object.keys(typeToComponentName)
@@ -33,7 +35,8 @@ export default Vue.extend({
   name: 'BaseInput',
 
   components: {
-    InputString
+    InputString,
+    InputNumber
   },
 
   props: {
@@ -79,4 +82,9 @@ patterns:
       value: string value
       availableTypes:
         - string
+  - name: Number
+    props:
+      value: 123
+      availableTypes:
+        - number
 </birdseye>

--- a/packages/@birdseye/app/src/components/InputBoolean.vue
+++ b/packages/@birdseye/app/src/components/InputBoolean.vue
@@ -1,0 +1,23 @@
+<template>
+  <input
+    type="checkbox"
+    class="input-boolean"
+    :checked="value"
+    @change="$emit('input', $event.target.checked)"
+  >
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'InputBoolean',
+
+  props: {
+    value: {
+      type: Boolean,
+      required: true
+    }
+  }
+})
+</script>

--- a/packages/@birdseye/app/src/components/InputBoolean.vue
+++ b/packages/@birdseye/app/src/components/InputBoolean.vue
@@ -1,8 +1,8 @@
 <template>
   <input
+    :checked="value"
     type="checkbox"
     class="input-boolean"
-    :checked="value"
     @change="$emit('input', $event.target.checked)"
   >
 </template>

--- a/packages/@birdseye/app/src/components/InputNumber.vue
+++ b/packages/@birdseye/app/src/components/InputNumber.vue
@@ -1,0 +1,23 @@
+<template>
+  <input
+    type="number"
+    class="input-number"
+    :value="value"
+    @input="$emit('input', Number($event.target.value))"
+  >
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'InputString',
+
+  props: {
+    value: {
+      type: Number,
+      required: true
+    }
+  }
+})
+</script>

--- a/packages/@birdseye/app/src/components/InputNumber.vue
+++ b/packages/@birdseye/app/src/components/InputNumber.vue
@@ -1,8 +1,8 @@
 <template>
   <input
+    :value="value"
     type="number"
     class="input-number"
-    :value="value"
     @input="$emit('input', Number($event.target.value))"
   >
 </template>

--- a/packages/@birdseye/app/src/components/InputString.vue
+++ b/packages/@birdseye/app/src/components/InputString.vue
@@ -1,8 +1,8 @@
 <template>
   <input
+    :value="value"
     type="text"
     class="input-string"
-    :value="value"
     @input="$emit('input', $event.target.value)"
   >
 </template>

--- a/packages/@birdseye/app/src/components/InputString.vue
+++ b/packages/@birdseye/app/src/components/InputString.vue
@@ -1,0 +1,23 @@
+<template>
+  <input
+    type="text"
+    class="input-string"
+    :value="value"
+    @input="$emit('input', $event.target.value)"
+  >
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'InputString',
+
+  props: {
+    value: {
+      type: String,
+      required: true
+    }
+  }
+})
+</script>

--- a/packages/@birdseye/app/tests/dummy/main.js
+++ b/packages/@birdseye/app/tests/dummy/main.js
@@ -1,12 +1,13 @@
 import Vue from 'vue'
 import birdseye from '@/main'
 import { createInstrument } from '@birdseye/vue'
+import BaseInput from '@/components/BaseInput.vue'
 import PanelPattern from '@/components/PanelPattern.vue'
 import style from './style.css'
 
 const load = ctx => ctx.keys().map(ctx)
 const components = load(require.context('./components', true, /\.vue$/)).concat(
-  PanelPattern
+  [BaseInput, PanelPattern]
 )
 
 // For debug

--- a/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
@@ -28,6 +28,19 @@ describe('BaseInput', () => {
       expect(select.value).toBe('number')
       expect(wrapper.html()).toMatchSnapshot()
     })
+
+    it('boolean', () => {
+      const wrapper = shallowMount(BaseInput, {
+        propsData: {
+          value: true,
+          availableTypes: ['boolean']
+        }
+      })
+
+      const select = wrapper.find('.select-type').element as HTMLSelectElement
+      expect(select.value).toBe('boolean')
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
 
   describe('events', () => {

--- a/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
@@ -1,0 +1,59 @@
+import { shallowMount } from '@vue/test-utils'
+import BaseInput from '@/components/BaseInput.vue'
+
+describe('BaseInput', () => {
+  describe('supported types', () => {
+    it('string', () => {
+      const wrapper = shallowMount(BaseInput, {
+        propsData: {
+          value: 'string value',
+          availableTypes: ['string']
+        }
+      })
+
+      const select = wrapper.find('.select-type').element as HTMLSelectElement
+      expect(select.value).toBe('string')
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+  })
+
+  describe('events', () => {
+    const Test = {
+      name: 'Test',
+      render(h: Function): any {
+        return h()
+      }
+    }
+
+    it('ports input event from the field', () => {
+      const wrapper = shallowMount(BaseInput, {
+        propsData: {
+          value: 'str',
+          availableTypes: ['string']
+        },
+        stubs: {
+          InputString: Test
+        }
+      })
+
+      wrapper.find(Test).vm.$emit('input', 'updated')
+      expect(wrapper.emitted('input')[0][0]).toBe('updated')
+    })
+
+    it('emits change-type event', () => {
+      const wrapper = shallowMount(BaseInput, {
+        propsData: {
+          value: 'str',
+          availableTypes: ['string', 'number']
+        }
+      })
+
+      const select = wrapper.find('.select-type')
+      const selectEl = select.element as HTMLSelectElement
+      selectEl.value = 'number'
+      select.trigger('change')
+
+      expect(wrapper.emitted('change-type')[0][0]).toBe('number')
+    })
+  })
+})

--- a/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
@@ -6,8 +6,7 @@ describe('BaseInput', () => {
     it('string', () => {
       const wrapper = shallowMount(BaseInput, {
         propsData: {
-          value: 'string value',
-          availableTypes: ['string']
+          value: 'string value'
         }
       })
 
@@ -19,8 +18,7 @@ describe('BaseInput', () => {
     it('number', () => {
       const wrapper = shallowMount(BaseInput, {
         propsData: {
-          value: 123,
-          availableTypes: ['number']
+          value: 123
         }
       })
 
@@ -32,8 +30,7 @@ describe('BaseInput', () => {
     it('boolean', () => {
       const wrapper = shallowMount(BaseInput, {
         propsData: {
-          value: true,
-          availableTypes: ['boolean']
+          value: true
         }
       })
 

--- a/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
@@ -15,6 +15,19 @@ describe('BaseInput', () => {
       expect(select.value).toBe('string')
       expect(wrapper.html()).toMatchSnapshot()
     })
+
+    it('number', () => {
+      const wrapper = shallowMount(BaseInput, {
+        propsData: {
+          value: 123,
+          availableTypes: ['number']
+        }
+      })
+
+      const select = wrapper.find('.select-type').element as HTMLSelectElement
+      expect(select.value).toBe('number')
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
 
   describe('events', () => {

--- a/packages/@birdseye/app/tests/unit/components/InputBoolean.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/InputBoolean.spec.ts
@@ -1,0 +1,32 @@
+import { shallowMount } from '@vue/test-utils'
+import InputBoolean from '@/components/InputBoolean.vue'
+
+describe('InputBoolean', () => {
+  it('applies input prop to actual element checked', () => {
+    const wrapper = shallowMount(InputBoolean, {
+      propsData: {
+        value: true
+      }
+    })
+    const input = wrapper.find('input').element as HTMLInputElement
+    expect(input.checked).toBe(true)
+
+    wrapper.setProps({
+      value: false
+    })
+    expect(input.checked).toBe(false)
+  })
+
+  it('emit input event when checkbox is changed', () => {
+    const wrapper = shallowMount(InputBoolean, {
+      propsData: {
+        value: true
+      }
+    })
+    const input = wrapper.find('input')
+    ;(input.element as HTMLInputElement).checked = false
+    input.trigger('change')
+
+    expect(wrapper.emitted('input')[0][0]).toBe(false)
+  })
+})

--- a/packages/@birdseye/app/tests/unit/components/InputNumber.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/InputNumber.spec.ts
@@ -1,0 +1,28 @@
+import { shallowMount } from '@vue/test-utils'
+import InputNumber from '@/components/InputNumber.vue'
+
+describe('InputNumber', () => {
+  it('applies input prop to actual element', () => {
+    const wrapper = shallowMount(InputNumber, {
+      propsData: {
+        value: 123
+      }
+    })
+    const input = wrapper.find('input').element as HTMLInputElement
+    expect(input.value).toBe('123')
+  })
+
+  it('ports input event with converting value to number', () => {
+    const wrapper = shallowMount(InputNumber, {
+      propsData: {
+        value: 123
+      }
+    })
+    const input = wrapper.find('input')
+    const inputEl = input.element as HTMLInputElement
+    inputEl.value = '456'
+    input.trigger('input')
+
+    expect(wrapper.emitted('input')[0][0]).toBe(456)
+  })
+})

--- a/packages/@birdseye/app/tests/unit/components/InputString.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/InputString.spec.ts
@@ -1,0 +1,28 @@
+import { shallowMount } from '@vue/test-utils'
+import InputString from '@/components/InputString.vue'
+
+describe('InputString', () => {
+  it('applies input prop to actual element', () => {
+    const wrapper = shallowMount(InputString, {
+      propsData: {
+        value: 'prop value'
+      }
+    })
+    const input = wrapper.find('input').element as HTMLInputElement
+    expect(input.value).toBe('prop value')
+  })
+
+  it('ports input event', () => {
+    const wrapper = shallowMount(InputString, {
+      propsData: {
+        value: 'prop value'
+      }
+    })
+    const input = wrapper.find('input')
+    const inputEl = input.element as HTMLInputElement
+    inputEl.value = 'updated'
+    input.trigger('input')
+
+    expect(wrapper.emitted('input')[0][0]).toBe('updated')
+  })
+})

--- a/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
+++ b/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BaseInput supported types number 1`] = `
+<div class="base-input">
+  <inputnumber-stub value="123"></inputnumber-stub>
+  <select class="select-type">
+    <option value="number">number</option>
+  </select>
+</div>
+`;
+
 exports[`BaseInput supported types string 1`] = `
 <div class="base-input">
   <inputstring-stub value="string value"></inputstring-stub>

--- a/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
+++ b/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
@@ -4,6 +4,8 @@ exports[`BaseInput supported types boolean 1`] = `
 <div class="base-input">
   <inputboolean-stub value="true"></inputboolean-stub>
   <select class="select-type">
+    <option value="string">string</option>
+    <option value="number">number</option>
     <option value="boolean">boolean</option>
   </select>
 </div>
@@ -13,7 +15,9 @@ exports[`BaseInput supported types number 1`] = `
 <div class="base-input">
   <inputnumber-stub value="123"></inputnumber-stub>
   <select class="select-type">
+    <option value="string">string</option>
     <option value="number">number</option>
+    <option value="boolean">boolean</option>
   </select>
 </div>
 `;
@@ -23,6 +27,8 @@ exports[`BaseInput supported types string 1`] = `
   <inputstring-stub value="string value"></inputstring-stub>
   <select class="select-type">
     <option value="string">string</option>
+    <option value="number">number</option>
+    <option value="boolean">boolean</option>
   </select>
 </div>
 `;

--- a/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
+++ b/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BaseInput supported types string 1`] = `
+<div class="base-input">
+  <inputstring-stub value="string value"></inputstring-stub>
+  <select class="select-type">
+    <option value="string">string</option>
+  </select>
+</div>
+`;

--- a/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
+++ b/packages/@birdseye/app/tests/unit/components/__snapshots__/BaseInput.spec.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BaseInput supported types boolean 1`] = `
+<div class="base-input">
+  <inputboolean-stub value="true"></inputboolean-stub>
+  <select class="select-type">
+    <option value="boolean">boolean</option>
+  </select>
+</div>
+`;
+
 exports[`BaseInput supported types number 1`] = `
 <div class="base-input">
   <inputnumber-stub value="123"></inputnumber-stub>


### PR DESCRIPTION
ref #2 

This PR adds input field components for `string`, `number` and `boolean` values. They simply wrap corresponding input DOM element and unify the prop and event interface.

`BaseInput` component orchestrate the input values by corresponding value types.

The user can change value type by changing `<select>` element along with the input field.

Input fields for more complex types such as array and object will be submitted in latter PRs.