### PR TITLE
feat(app): allow to edit props and data value in preview

### DIFF
--- a/packages/@birdseye/app/package.json
+++ b/packages/@birdseye/app/package.json
@@ -39,6 +39,7 @@
     "@vue/web-component-wrapper": "^1.2.0",
     "k-css": "^2.0.0",
     "vue": "^2.5.17",
+    "vue-lazy-components-option": "^0.1.0",
     "vue-router": "^3.0.1",
     "vue-transition-components": "^0.2.2"
   },

--- a/packages/@birdseye/app/package.json
+++ b/packages/@birdseye/app/package.json
@@ -39,7 +39,7 @@
     "@vue/web-component-wrapper": "^1.2.0",
     "k-css": "^2.0.0",
     "vue": "^2.5.17",
-    "vue-lazy-components-option": "^0.1.0",
+    "vue-lazy-components-option": "^0.1.1",
     "vue-router": "^3.0.1",
     "vue-transition-components": "^0.2.2"
   },

--- a/packages/@birdseye/app/src/App.vue
+++ b/packages/@birdseye/app/src/App.vue
@@ -55,54 +55,14 @@ export default Vue.extend({
       return this.store ? this.store.state.declarations.map(d => d.meta) : []
     },
 
-    currentMeta(): ComponentMeta | undefined {
-      const { meta: metaName } = this.$route.params
-      return this.meta.find(m => m.name === metaName)
-    },
-
-    currentPattern(): ComponentPattern | undefined {
-      if (!this.currentMeta) {
-        return
-      }
-
-      const { pattern: patternName } = this.$route.params
-      return this.currentMeta.patterns.find(p => p.name === patternName)
-    },
-
     props(): PatternData[] {
-      if (!this.currentMeta || !this.currentPattern) {
-        return []
-      }
-
-      const { currentMeta: meta, currentPattern: pattern } = this
-
-      return Object.keys(pattern.props).map(name => {
-        const info = meta.props[name]
-        const value = pattern.props[name]
-        return {
-          type: info ? info.type : [],
-          name,
-          value
-        }
-      })
+      const { meta, pattern } = this.$route.params
+      return this.store ? this.store.getQualifiedProps(meta, pattern) : []
     },
 
     data(): PatternData[] {
-      if (!this.currentMeta || !this.currentPattern) {
-        return []
-      }
-
-      const { currentMeta: meta, currentPattern: pattern } = this
-
-      return Object.keys(pattern.data).map(name => {
-        const info = meta.data[name]
-        const value = pattern.data[name]
-        return {
-          type: info ? info.type : [],
-          name,
-          value
-        }
-      })
+      const { meta, pattern } = this.$route.params
+      return this.store ? this.store.getQualifiedData(meta, pattern) : []
     }
   },
 

--- a/packages/@birdseye/app/src/App.vue
+++ b/packages/@birdseye/app/src/App.vue
@@ -29,6 +29,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { ComponentMeta, ComponentPattern } from '@birdseye/core'
+import AppStore from './store'
 import NavSide from './components/NavSide.vue'
 import PanelPattern, { PatternData } from './components/PanelPattern.vue'
 
@@ -39,13 +40,21 @@ export default Vue.extend({
   },
 
   props: {
-    meta: {
-      type: Array as () => ComponentMeta[],
-      default: () => []
+    store: {
+      type: Object as () => AppStore | undefined,
+
+      // Actually required
+      // Since it is wrapped by WebComponents and props are passed
+      // after the component is instantiated, we cannot just use `required`.
+      default: undefined
     }
   },
 
   computed: {
+    meta(): ComponentMeta[] {
+      return this.store ? this.store.state.declarations.map(d => d.meta) : []
+    },
+
     currentMeta(): ComponentMeta | undefined {
       const { meta: metaName } = this.$route.params
       return this.meta.find(m => m.name === metaName)

--- a/packages/@birdseye/app/src/App.vue
+++ b/packages/@birdseye/app/src/App.vue
@@ -19,6 +19,8 @@
           <PanelPattern
             :props="props"
             :data="data"
+            @input-prop="onInputProp"
+            @input-data="onInputData"
           />
         </div>
       </div>
@@ -29,9 +31,9 @@
 <script lang="ts">
 import Vue from 'vue'
 import { ComponentMeta, ComponentPattern } from '@birdseye/core'
-import AppStore from './store'
+import AppStore, { QualifiedData } from './store'
 import NavSide from './components/NavSide.vue'
-import PanelPattern, { PatternData } from './components/PanelPattern.vue'
+import PanelPattern from './components/PanelPattern.vue'
 
 export default Vue.extend({
   components: {
@@ -55,12 +57,12 @@ export default Vue.extend({
       return this.store ? this.store.state.declarations.map(d => d.meta) : []
     },
 
-    props(): PatternData[] {
+    props(): QualifiedData[] {
       const { meta, pattern } = this.$route.params
       return this.store ? this.store.getQualifiedProps(meta, pattern) : []
     },
 
-    data(): PatternData[] {
+    data(): QualifiedData[] {
       const { meta, pattern } = this.$route.params
       return this.store ? this.store.getQualifiedData(meta, pattern) : []
     }
@@ -71,6 +73,22 @@ export default Vue.extend({
     const slot = document.createElement('slot')
     const wrapper = this.$refs.slot as HTMLElement
     wrapper.appendChild(slot)
+  },
+
+  methods: {
+    onInputProp({ name, value }: { name: string; value: any }): void {
+      if (!this.store) return
+
+      const { meta, pattern } = this.$route.params
+      this.store.updatePropValue(meta, pattern, name, value)
+    },
+
+    onInputData({ name, value }: { name: string; value: any }): void {
+      if (!this.store) return
+
+      const { meta, pattern } = this.$route.params
+      this.store.updateDataValue(meta, pattern, name, value)
+    }
   }
 })
 </script>

--- a/packages/@birdseye/app/src/Preview.vue
+++ b/packages/@birdseye/app/src/Preview.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Vue, { VNode } from 'vue'
 import { ComponentDeclaration, ComponentPattern } from '@birdseye/core'
+import AppStore from './store'
 
 export default Vue.extend({
   props: {
@@ -14,15 +15,15 @@ export default Vue.extend({
       default: null
     },
 
-    declarations: {
-      type: Array as () => ComponentDeclaration[],
+    store: {
+      type: Object as () => AppStore,
       required: true
     }
   },
 
   computed: {
     targetDeclaration(): ComponentDeclaration | undefined {
-      return this.declarations.filter(d => {
+      return this.store.state.declarations.filter(d => {
         return d.meta.name === this.meta
       })[0]
     },

--- a/packages/@birdseye/app/src/Preview.vue
+++ b/packages/@birdseye/app/src/Preview.vue
@@ -23,19 +23,9 @@ export default Vue.extend({
 
   computed: {
     targetDeclaration(): ComponentDeclaration | undefined {
-      return this.store.state.declarations.filter(d => {
+      return this.store.state.declarations.find(d => {
         return d.meta.name === this.meta
-      })[0]
-    },
-
-    targetPattern(): ComponentPattern | undefined {
-      const decl = this.targetDeclaration
-
-      if (!decl || !this.pattern) return
-
-      return decl.meta.patterns.filter(p => {
-        return p.name === this.pattern
-      })[0]
+      })
     }
   },
 
@@ -45,12 +35,12 @@ export default Vue.extend({
     }
 
     const { Wrapper } = this.targetDeclaration
-    const { props, data } = this.targetPattern || { props: {}, data: {} }
+    const pattern = this.store.getPattern(this.meta, this.pattern)
 
     return h(Wrapper, {
       props: {
-        props,
-        data
+        props: pattern ? pattern.props : {},
+        data: pattern ? pattern.data : {}
       }
     })
   }

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -11,7 +11,7 @@
       v-if="!removeTypes"
       :value="typeOfValue"
       class="select-type"
-      @change="$emit('change-type', $event.target.value)"
+      @change="onChangeType($event.target.value)"
     >
       <option
         v-for="type in realAvailableTypes"
@@ -29,6 +29,8 @@ import InputNumber from './InputNumber.vue'
 import InputBoolean from './InputBoolean.vue'
 import InputArray from './InputArray.vue'
 import InputObject from './InputObject.vue'
+import { emptyValue } from '@/utils'
+import { ComponentDataType } from '@birdseye/core'
 
 const typeToComponentName: Record<string, string> = {
   string: 'InputString',
@@ -107,6 +109,13 @@ export default Vue.extend({
 
     componentForType(): string {
       return typeToComponentName[this.typeOfValue]
+    }
+  },
+
+  methods: {
+    onChangeType(type: ComponentDataType): void {
+      const empty = emptyValue(type)
+      this.$emit('input', empty)
     }
   }
 })

--- a/packages/@birdseye/app/src/components/BaseInput.vue
+++ b/packages/@birdseye/app/src/components/BaseInput.vue
@@ -40,16 +40,19 @@ const typeToComponentName: Record<string, string> = {
 
 const possibleTypes = Object.keys(typeToComponentName)
 
+const lazyComponents = () => ({
+  InputString,
+  InputNumber,
+  InputBoolean,
+  InputArray,
+  InputObject
+})
+
 export default Vue.extend({
   name: 'BaseInput',
 
-  components: {
-    InputString,
-    InputNumber,
-    InputBoolean,
-    InputArray,
-    InputObject
-  },
+  components: lazyComponents(),
+  lazyComponents,
 
   props: {
     value: {

--- a/packages/@birdseye/app/src/components/InputArray.vue
+++ b/packages/@birdseye/app/src/components/InputArray.vue
@@ -28,12 +28,15 @@
 import Vue from 'vue'
 import InputProperty from './InputProperty.vue'
 
+const lazyComponents = () => ({
+  InputProperty
+})
+
 export default Vue.extend({
   name: 'InputArray',
 
-  components: {
-    InputProperty
-  },
+  components: lazyComponents(),
+  lazyComponents,
 
   props: {
     value: {

--- a/packages/@birdseye/app/src/components/InputObject.vue
+++ b/packages/@birdseye/app/src/components/InputObject.vue
@@ -28,12 +28,15 @@
 import Vue from 'vue'
 import InputProperty from './InputProperty.vue'
 
+const lazyComponents = () => ({
+  InputProperty
+})
+
 export default Vue.extend({
   name: 'InputObject',
 
-  components: {
-    InputProperty
-  },
+  components: lazyComponents(),
+  lazyComponents,
 
   props: {
     value: {

--- a/packages/@birdseye/app/src/components/InputPropertyObject.vue
+++ b/packages/@birdseye/app/src/components/InputPropertyObject.vue
@@ -32,12 +32,15 @@
 import Vue from 'vue'
 import BaseInput from './BaseInput.vue'
 
+const lazyComponents = () => ({
+  BaseInput
+})
+
 export default Vue.extend({
   name: 'InputPropertyPrimitive',
 
-  components: {
-    BaseInput
-  },
+  components: lazyComponents(),
+  lazyComponents,
 
   props: {
     name: {
@@ -48,14 +51,7 @@ export default Vue.extend({
     value: {
       type: [Array, Object],
       required: true
-    }
-  },
 
-  beforeCreate() {
-    const components = this.$options.components!
-    // To avoid BaseInput to be undefined due to circlar dependency
-    if (!components.BaseInput) {
-      components.BaseInput = BaseInput
     }
   }
 })

--- a/packages/@birdseye/app/src/components/InputPropertyObject.vue
+++ b/packages/@birdseye/app/src/components/InputPropertyObject.vue
@@ -6,6 +6,7 @@
       <div class="type">
         <BaseInput
           :value="value"
+          :available-types="availableTypes"
           remove-input
         />
       </div>
@@ -51,7 +52,11 @@ export default Vue.extend({
     value: {
       type: [Array, Object],
       required: true
+    },
 
+    availableTypes: {
+      type: Array as () => string[],
+      default: () => []
     }
   }
 })

--- a/packages/@birdseye/app/src/components/InputPropertyObject.vue
+++ b/packages/@birdseye/app/src/components/InputPropertyObject.vue
@@ -8,6 +8,7 @@
           :value="value"
           :available-types="availableTypes"
           remove-input
+          @input="$emit('input', arguments[0])"
         />
       </div>
 

--- a/packages/@birdseye/app/src/components/InputPropertyPrimitive.vue
+++ b/packages/@birdseye/app/src/components/InputPropertyPrimitive.vue
@@ -20,8 +20,15 @@
 import Vue from 'vue'
 import BaseInput from './BaseInput.vue'
 
+const lazyComponents = () => ({
+  BaseInput
+})
+
 export default Vue.extend({
   name: 'InputPropertyPrimitive',
+
+  components: lazyComponents(),
+  lazyComponents,
 
   props: {
     name: {
@@ -32,14 +39,7 @@ export default Vue.extend({
     value: {
       type: [String, Number, Boolean],
       default: undefined
-    }
-  },
 
-  beforeCreate() {
-    const components = this.$options.components!
-    // To avoid BaseInput to be undefined due to circlar dependency
-    if (!components.BaseInput) {
-      components.BaseInput = BaseInput
     }
   }
 })

--- a/packages/@birdseye/app/src/components/InputPropertyPrimitive.vue
+++ b/packages/@birdseye/app/src/components/InputPropertyPrimitive.vue
@@ -4,6 +4,7 @@
 
     <BaseInput
       :value="value"
+      :available-types="availableTypes"
       @input="$emit('input', arguments[0])"
     />
 
@@ -39,7 +40,11 @@ export default Vue.extend({
     value: {
       type: [String, Number, Boolean],
       default: undefined
+    },
 
+    availableTypes: {
+      type: Array as () => string[],
+      default: () => []
     }
   }
 })

--- a/packages/@birdseye/app/src/components/PanelPattern.vue
+++ b/packages/@birdseye/app/src/components/PanelPattern.vue
@@ -4,11 +4,13 @@
       :data="props"
       class="group"
       title="props"
+      @input="$emit('input-prop', arguments[0])"
     />
     <PanelPatternGroup
       :data="data"
       class="group"
       title="data"
+      @input="$emit('input-data', arguments[0])"
     />
   </div>
 </template>
@@ -17,12 +19,7 @@
 import Vue from 'vue'
 import { ComponentDataType } from '@birdseye/core'
 import PanelPatternGroup from './PanelPatternGroup.vue'
-
-export interface PatternData {
-  type: ComponentDataType[]
-  name: string
-  value: any
-}
+import { QualifiedData } from '@/store'
 
 function patternDataValidator(value: any[]) {
   return value.every(v => {
@@ -41,13 +38,13 @@ export default Vue.extend({
 
   props: {
     props: {
-      type: Array as () => PatternData[],
+      type: Array as () => QualifiedData[],
       required: true,
       validator: patternDataValidator
     },
 
     data: {
-      type: Array as () => PatternData[],
+      type: Array as () => QualifiedData[],
       required: true,
       validator: patternDataValidator
     }
@@ -75,14 +72,18 @@ patterns:
   - name: Normal
     props:
       props:
-        - type: string
+        - type:
+            - string
           name: foo
           value: foo value
       data:
-        - type: number
+        - type:
+            - string
+            - number
           name: bar
           value: 123
-        - type: boolean
+        - type:
+            - boolean
           name: baz
           value: true
 </birdseye>

--- a/packages/@birdseye/app/src/components/PanelPatternGroup.vue
+++ b/packages/@birdseye/app/src/components/PanelPatternGroup.vue
@@ -13,13 +13,23 @@
         :key="item.name"
         class="item"
       >
-        <strong class="name">
-          {{ item.name }}
-        </strong>
+        <template v-if="isProduction">
+          <strong class="name">
+            {{ item.name }}
+          </strong>
 
-        <span class="value">
-          {{ item.value }}
-        </span>
+          <span class="value">
+            {{ item.value }}
+          </span>
+        </template>
+
+        <InputProperty
+          v-else
+          :name="item.name"
+          :value="item.value"
+          :available-types="item.type"
+          @input="onInput(item.name, arguments[0])"
+        />
       </li>
     </ul>
 
@@ -34,10 +44,15 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { PatternData } from './PanelPattern.vue'
+import InputProperty from './InputProperty.vue'
+import { QualifiedData } from '@/store'
 
 export default Vue.extend({
   name: 'PanelPatternGroup',
+
+  components: {
+    InputProperty
+  },
 
   props: {
     title: {
@@ -46,8 +61,23 @@ export default Vue.extend({
     },
 
     data: {
-      type: Array as () => PatternData[],
+      type: Array as () => QualifiedData[],
       required: true
+    }
+  },
+
+  computed: {
+    isProduction(): boolean {
+      return process.env.NODE_ENV === 'production'
+    }
+  },
+
+  methods: {
+    onInput(name: string, value: any): void {
+      this.$emit('input', {
+        name,
+        value
+      })
     }
   }
 })

--- a/packages/@birdseye/app/src/main.ts
+++ b/packages/@birdseye/app/src/main.ts
@@ -3,6 +3,7 @@ import wrap from '@vue/web-component-wrapper'
 import { ComponentDeclaration } from '@birdseye/core'
 import LazyComponents from 'vue-lazy-components-option'
 import router from './router'
+import AppStore from './store'
 import App from './App.vue'
 
 Vue.use(LazyComponents)
@@ -25,7 +26,11 @@ export default function birdseye(
   const wrapper = typeof el === 'string' ? document.querySelector(el) : el
   wrapper!.appendChild(app)
 
-  app.meta = declarations.map(d => d.meta)
+  const store = new AppStore({
+    declarations
+  })
+
+  app.store = store
 
   new Root({
     el: content,
@@ -33,7 +38,7 @@ export default function birdseye(
       // Preview.vue
       h('router-view', {
         attrs: {
-          declarations
+          store
         }
       })
   })

--- a/packages/@birdseye/app/src/main.ts
+++ b/packages/@birdseye/app/src/main.ts
@@ -1,8 +1,11 @@
 import Vue from 'vue'
 import wrap from '@vue/web-component-wrapper'
 import { ComponentDeclaration } from '@birdseye/core'
+import LazyComponents from 'vue-lazy-components-option'
 import router from './router'
 import App from './App.vue'
+
+Vue.use(LazyComponents)
 
 const appTagName = 'birdseye-app'
 const Root = Vue.extend({ router })

--- a/packages/@birdseye/app/src/store.ts
+++ b/packages/@birdseye/app/src/store.ts
@@ -1,5 +1,11 @@
 import Vue from 'vue'
-import { ComponentDeclaration } from '@birdseye/core'
+import {
+  ComponentDeclaration,
+  ComponentPattern,
+  ComponentMeta,
+  ComponentDataType
+} from '@birdseye/core'
+import { dedupe } from './utils'
 
 class Store<S> {
   private vm: Vue
@@ -19,7 +25,87 @@ interface AppState {
   declarations: ComponentDeclaration[]
 }
 
+export interface QualifiedData {
+  type: ComponentDataType[]
+  name: string
+  value: any
+}
+
 /**
  * Light-weight store to handle changing pattern values
  */
-export default class AppStore extends Store<AppState> {}
+export default class AppStore extends Store<AppState> {
+  getMeta(metaName: string): ComponentMeta | undefined {
+    return this.state.declarations
+      .map(d => d.meta)
+      .find(m => m.name === metaName)
+  }
+
+  getPattern(
+    metaName: string,
+    patternName: string
+  ): ComponentPattern | undefined {
+    const meta = this.getMeta(metaName)
+
+    if (!meta) return
+
+    return meta.patterns.find(p => p.name === patternName)
+  }
+
+  getQualifiedProps(metaName: string, patternName?: string): QualifiedData[] {
+    return this.genericQualifiedData(metaName, patternName, 'props')
+  }
+
+  getQualifiedData(metaName: string, patternName?: string): QualifiedData[] {
+    return this.genericQualifiedData(metaName, patternName, 'data')
+  }
+
+  updatePropValue(
+    meta: string,
+    pattern: string,
+    key: string,
+    value: any
+  ): void {
+    const p = this.getPattern(meta, pattern)
+    if (!p) return
+
+    p.props[key] = value
+  }
+
+  updateDataValue(
+    meta: string,
+    pattern: string,
+    key: string,
+    value: any
+  ): void {
+    const p = this.getPattern(meta, pattern)
+    if (!p) return
+
+    p.data[key] = value
+  }
+
+  private genericQualifiedData(
+    metaName: string,
+    patternName: string | undefined,
+    type: 'props' | 'data'
+  ): QualifiedData[] {
+    const meta = this.getMeta(metaName)
+    if (!meta) return []
+
+    const pattern = patternName && this.getPattern(metaName, patternName)
+    const names = dedupe([
+      ...Object.keys(meta[type]),
+      ...(pattern ? Object.keys(pattern[type]) : [])
+    ])
+
+    return names.map(name => {
+      const info = meta[type][name]
+      const value = pattern ? pattern[type][name] : undefined
+      return {
+        type: info ? info.type : [],
+        name,
+        value
+      }
+    })
+  }
+}

--- a/packages/@birdseye/app/src/store.ts
+++ b/packages/@birdseye/app/src/store.ts
@@ -36,9 +36,8 @@ export interface QualifiedData {
  */
 export default class AppStore extends Store<AppState> {
   getMeta(metaName: string): ComponentMeta | undefined {
-    return this.state.declarations
-      .map(d => d.meta)
-      .find(m => m.name === metaName)
+    const decl = this.state.declarations.find(d => d.meta.name === metaName)
+    return decl && decl.meta
   }
 
   getPattern(

--- a/packages/@birdseye/app/src/store.ts
+++ b/packages/@birdseye/app/src/store.ts
@@ -1,0 +1,25 @@
+import Vue from 'vue'
+import { ComponentDeclaration } from '@birdseye/core'
+
+class Store<S> {
+  private vm: Vue
+
+  constructor(initialState: S) {
+    this.vm = new Vue({
+      data: initialState
+    })
+  }
+
+  get state(): S {
+    return this.vm.$data as S
+  }
+}
+
+interface AppState {
+  declarations: ComponentDeclaration[]
+}
+
+/**
+ * Light-weight store to handle changing pattern values
+ */
+export default class AppStore extends Store<AppState> {}

--- a/packages/@birdseye/app/src/utils.ts
+++ b/packages/@birdseye/app/src/utils.ts
@@ -1,3 +1,5 @@
+import { ComponentDataType } from '@birdseye/core'
+
 export function dedupe(list: string[]): string[] {
   const set: Record<string, true> = {}
   return list.reduce<string[]>((acc, item) => {
@@ -7,4 +9,15 @@ export function dedupe(list: string[]): string[] {
     set[item] = true
     return acc.concat(item)
   }, [])
+}
+
+export function emptyValue(type: ComponentDataType): any {
+  const map = {
+    string: '',
+    number: 0,
+    boolean: false,
+    array: [],
+    object: {}
+  }
+  return map[type]
 }

--- a/packages/@birdseye/app/src/utils.ts
+++ b/packages/@birdseye/app/src/utils.ts
@@ -1,0 +1,10 @@
+export function dedupe(list: string[]): string[] {
+  const set: Record<string, true> = {}
+  return list.reduce<string[]>((acc, item) => {
+    if (set[item]) {
+      return acc
+    }
+    set[item] = true
+    return acc.concat(item)
+  }, [])
+}

--- a/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/BaseInput.spec.ts
@@ -1,5 +1,6 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, Wrapper } from '@vue/test-utils'
 import BaseInput from '@/components/BaseInput.vue'
+import { ComponentDataType } from '@birdseye/core'
 
 describe('BaseInput', () => {
   describe('rendering', () => {
@@ -112,21 +113,48 @@ describe('BaseInput', () => {
       wrapper.find(Test).vm.$emit('input', 'updated')
       expect(wrapper.emitted('input')[0][0]).toBe('updated')
     })
+  })
 
-    it('emits change-type event', () => {
-      const wrapper = shallowMount(BaseInput, {
-        propsData: {
-          value: 'str',
-          availableTypes: ['string', 'number']
-        }
-      })
-
+  describe('will emit input event with empty value when the type is changed', () => {
+    function changeType(wrapper: Wrapper<any>, type: ComponentDataType): void {
       const select = wrapper.find('.select-type')
       const selectEl = select.element as HTMLSelectElement
-      selectEl.value = 'number'
+      selectEl.value = type
       select.trigger('change')
+    }
 
-      expect(wrapper.emitted('change-type')[0][0]).toBe('number')
+    let wrapper: Wrapper<any>
+    beforeEach(() => {
+      wrapper = shallowMount(BaseInput, {
+        propsData: {
+          value: 'str'
+        }
+      })
+    })
+
+    it('string', () => {
+      changeType(wrapper, 'string')
+      expect(wrapper.emitted('input')[0][0]).toBe('')
+    })
+
+    it('number', () => {
+      changeType(wrapper, 'number')
+      expect(wrapper.emitted('input')[0][0]).toBe(0)
+    })
+
+    it('boolean', () => {
+      changeType(wrapper, 'boolean')
+      expect(wrapper.emitted('input')[0][0]).toBe(false)
+    })
+
+    it('array', () => {
+      changeType(wrapper, 'array')
+      expect(wrapper.emitted('input')[0][0]).toEqual([])
+    })
+
+    it('object', () => {
+      changeType(wrapper, 'object')
+      expect(wrapper.emitted('input')[0][0]).toEqual({})
     })
   })
 })

--- a/packages/@birdseye/app/tests/unit/components/InputPropertyObject.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/InputPropertyObject.spec.ts
@@ -44,9 +44,14 @@ describe('InputPropertyObject', () => {
         value: ['foo']
       }
     })
-    const input = findValueInput(wrapper)
-    input.vm.$emit('input', ['bar'])
-    expect(wrapper.emitted('input')[0][0]).toEqual(['bar'])
+    const type = findTypeInput(wrapper)
+    type.vm.$emit('input', {})
+
+    const value = findValueInput(wrapper)
+    value.vm.$emit('input', ['bar'])
+
+    expect(wrapper.emitted('input')[0][0]).toEqual({})
+    expect(wrapper.emitted('input')[1][0]).toEqual(['bar'])
   })
 
   it('listens remove events', () => {

--- a/packages/@birdseye/app/tests/unit/components/InputPropertyObject.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/InputPropertyObject.spec.ts
@@ -3,6 +3,10 @@ import InputPropertyObject from '@/components/InputPropertyObject.vue'
 import BaseInput from '@/components/BaseInput.vue'
 
 describe('InputPropertyObject', () => {
+  function findTypeInput(wrapper: Wrapper<any>) {
+    return wrapper.findAll(BaseInput).wrappers.find(w => !w.props().removeType)!
+  }
+
   function findValueInput(wrapper: Wrapper<any>) {
     return wrapper
       .findAll(BaseInput)
@@ -19,6 +23,18 @@ describe('InputPropertyObject', () => {
     wrapper.findAll(BaseInput).wrappers.forEach(input => {
       expect(input.props().value).toEqual(['foo', 'bar'])
     })
+  })
+
+  it('ports available types to the form component', () => {
+    const wrapper = shallowMount(InputPropertyObject, {
+      propsData: {
+        name: 'propname',
+        value: ['test'],
+        availableTypes: ['array', 'object']
+      }
+    })
+    const input = findTypeInput(wrapper)
+    expect(input.props().availableTypes).toEqual(['array', 'object'])
   })
 
   it('listens input events from the form component', () => {

--- a/packages/@birdseye/app/tests/unit/components/InputPropertyPrimitive.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/InputPropertyPrimitive.spec.ts
@@ -14,6 +14,18 @@ describe('InputPropertyPrimitive', () => {
     expect(input.props().value).toBe('foo')
   })
 
+  it('ports available types to the form component', () => {
+    const wrapper = shallowMount(InputPropertyPrimitive, {
+      propsData: {
+        name: 'propname',
+        value: 'test',
+        availableTypes: ['string', 'number']
+      }
+    })
+    const input = wrapper.find(BaseInput)
+    expect(input.props().availableTypes).toEqual(['string', 'number'])
+  })
+
   it('listens input events from the form component', () => {
     const wrapper = shallowMount(InputPropertyPrimitive, {
       propsData: {

--- a/packages/@birdseye/app/tests/unit/components/PanelPattern.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/PanelPattern.spec.ts
@@ -3,6 +3,7 @@ import PanelPattern from '@/components/PanelPattern.vue'
 
 describe('PanelPattern', () => {
   const StubGroup = {
+    name: 'PanelPatternGroup',
     props: ['title', 'data'],
 
     render(this: any, h: Function): any {
@@ -36,5 +37,59 @@ describe('PanelPattern', () => {
       }
     })
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('propagates events from props', () => {
+    const wrapper = shallowMount(PanelPattern, {
+      propsData: {
+        props: [
+          {
+            type: ['string', 'number'],
+            name: 'foo',
+            value: 'str'
+          }
+        ],
+        data: []
+      },
+      stubs: {
+        PanelPatternGroup: StubGroup
+      }
+    })
+    const group = wrapper.findAll(StubGroup).at(0)
+    group.vm.$emit('input', {
+      name: 'foo',
+      value: 'test'
+    })
+    expect(wrapper.emitted('input-prop')[0][0]).toEqual({
+      name: 'foo',
+      value: 'test'
+    })
+  })
+
+  it('propagates events from data', () => {
+    const wrapper = shallowMount(PanelPattern, {
+      propsData: {
+        props: [],
+        data: [
+          {
+            type: [],
+            name: 'foo',
+            value: 'str'
+          }
+        ]
+      },
+      stubs: {
+        PanelPatternGroup: StubGroup
+      }
+    })
+    const group = wrapper.findAll(StubGroup).at(1)
+    group.vm.$emit('input', {
+      name: 'foo',
+      value: 'test'
+    })
+    expect(wrapper.emitted('input-data')[0][0]).toEqual({
+      name: 'foo',
+      value: 'test'
+    })
   })
 })

--- a/packages/@birdseye/app/tests/unit/components/PanelPatternGroup.spec.ts
+++ b/packages/@birdseye/app/tests/unit/components/PanelPatternGroup.spec.ts
@@ -2,24 +2,36 @@ import { shallowMount } from '@vue/test-utils'
 import PanelPatternGroup from '@/components/PanelPatternGroup.vue'
 
 describe('PanelPatternGroup', () => {
-  it('renders title and data', () => {
-    const data = [
-      {
-        type: ['string'],
-        name: 'foo',
-        value: 'string value'
-      },
-      {
-        type: ['number'],
-        name: 'bar',
-        value: 123
-      }
-    ]
+  const dummyData = [
+    {
+      type: ['string'],
+      name: 'foo',
+      value: 'string value'
+    },
+    {
+      type: ['number'],
+      name: 'bar',
+      value: 123
+    },
+    {
+      type: ['string', 'number'],
+      name: 'baz',
+      value: 'test'
+    }
+  ]
 
+  const StubInputProperty = {
+    name: 'InputProperty',
+    render(h: Function) {
+      return h()
+    }
+  }
+
+  it('renders title and data', () => {
     const wrapper = shallowMount(PanelPatternGroup, {
       propsData: {
         title: 'title string',
-        data
+        data: dummyData
       }
     })
     expect(wrapper.html()).toMatchSnapshot()
@@ -33,5 +45,24 @@ describe('PanelPatternGroup', () => {
       }
     })
     expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  it('propagates input events', () => {
+    const wrapper = shallowMount(PanelPatternGroup, {
+      propsData: {
+        title: 'title',
+        data: dummyData
+      },
+      stubs: {
+        InputProperty: StubInputProperty
+      }
+    })
+
+    const input = wrapper.findAll(StubInputProperty).at(1)
+    input.vm.$emit('input', 456)
+    expect(wrapper.emitted('input')[0][0]).toEqual({
+      name: 'bar',
+      value: 456
+    })
   })
 })

--- a/packages/@birdseye/app/tests/unit/components/__snapshots__/PanelPatternGroup.spec.ts.snap
+++ b/packages/@birdseye/app/tests/unit/components/__snapshots__/PanelPatternGroup.spec.ts.snap
@@ -15,16 +15,15 @@ exports[`PanelPatternGroup renders title and data 1`] = `
     title string
   </strong>
   <ul class="list">
-    <li class="item"><strong class="name">
-        foo
-      </strong> <span class="value">
-        string value
-      </span></li>
-    <li class="item"><strong class="name">
-        bar
-      </strong> <span class="value">
-        123
-      </span></li>
+    <li class="item">
+      <inputproperty-stub value="string value" name="foo" available-types="string"></inputproperty-stub>
+    </li>
+    <li class="item">
+      <inputproperty-stub value="123" name="bar" available-types="number"></inputproperty-stub>
+    </li>
+    <li class="item">
+      <inputproperty-stub value="test" name="baz" available-types="string,number"></inputproperty-stub>
+    </li>
   </ul>
 </div>
 `;

--- a/packages/@birdseye/app/tests/unit/setup.ts
+++ b/packages/@birdseye/app/tests/unit/setup.ts
@@ -1,3 +1,7 @@
+import Vue from 'vue'
+import LazyComponents from 'vue-lazy-components-option'
 import { config } from '@vue/test-utils'
+
+Vue.use(LazyComponents)
 
 config.logModifiedComponents = false

--- a/packages/@birdseye/app/tests/unit/store.spec.ts
+++ b/packages/@birdseye/app/tests/unit/store.spec.ts
@@ -1,0 +1,204 @@
+import AppStore from '@/store'
+
+describe('AppStore', () => {
+  describe('qualified values', () => {
+    let store: AppStore
+    beforeEach(() => {
+      store = new AppStore({
+        declarations: [
+          {
+            Wrapper: {} as any,
+            meta: {
+              name: 'foo',
+              props: {
+                a: {
+                  type: ['string']
+                },
+                b: {
+                  type: ['string', 'number']
+                }
+              },
+              data: {
+                c: {
+                  type: ['boolean']
+                }
+              },
+              patterns: [
+                {
+                  name: 'pattern 1',
+                  props: {
+                    a: 'test1',
+                    b: 123
+                  },
+                  data: {
+                    c: true
+                  }
+                },
+                {
+                  name: 'pattern 2',
+                  props: {
+                    a: 'test2',
+                    b: '123'
+                  },
+                  data: {
+                    c: false
+                  }
+                }
+              ]
+            }
+          },
+          {
+            Wrapper: {} as any,
+            meta: {
+              name: 'bar',
+              props: {},
+              data: {
+                test1: {
+                  type: ['string']
+                }
+              },
+              patterns: [
+                {
+                  name: 'pattern 3',
+                  props: {},
+                  data: {
+                    test2: 'test value'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      })
+    })
+
+    it('qualifies props', () => {
+      const props = store.getQualifiedProps('foo', 'pattern 1')
+      expect(props).toEqual([
+        {
+          type: ['string'],
+          name: 'a',
+          value: 'test1'
+        },
+        {
+          type: ['string', 'number'],
+          name: 'b',
+          value: 123
+        }
+      ])
+    })
+
+    it('qualifies data', () => {
+      const data = store.getQualifiedData('foo', 'pattern 2')
+      expect(data).toEqual([
+        {
+          type: ['boolean'],
+          name: 'c',
+          value: false
+        }
+      ])
+    })
+
+    it('qualifies props without pattern', () => {
+      const props = store.getQualifiedProps('foo')
+      expect(props).toEqual([
+        {
+          type: ['string'],
+          name: 'a',
+          value: undefined
+        },
+        {
+          type: ['string', 'number'],
+          name: 'b',
+          value: undefined
+        }
+      ])
+    })
+
+    it('qualifies data without pattern', () => {
+      const data = store.getQualifiedData('foo')
+      expect(data).toEqual([
+        {
+          type: ['boolean'],
+          name: 'c',
+          value: undefined
+        }
+      ])
+    })
+
+    it('merges meta and pattern properties', () => {
+      const data = store.getQualifiedData('bar', 'pattern 3')
+      expect(data).toEqual([
+        {
+          type: ['string'],
+          name: 'test1',
+          value: undefined
+        },
+        {
+          type: [],
+          name: 'test2',
+          value: 'test value'
+        }
+      ])
+    })
+  })
+
+  describe('others', () => {
+    let store: AppStore
+    beforeEach(() => {
+      store = new AppStore({
+        declarations: [
+          {
+            Wrapper: {} as any,
+            meta: {
+              name: 'foo',
+              props: {},
+              data: {},
+              patterns: [
+                {
+                  name: 'foo pattern 1',
+                  props: {
+                    a: 'test value'
+                  },
+                  data: {
+                    b: 123,
+                    c: true
+                  }
+                },
+                {
+                  name: 'foo pattern 2',
+                  props: {},
+                  data: {
+                    b: 456
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      })
+    })
+
+    it('gets meta', () => {
+      const m = store.getMeta('foo')
+      expect(m).toBe(store.state.declarations[0].meta)
+    })
+
+    it('gets a pattern', () => {
+      const p = store.getPattern('foo', 'foo pattern 2')
+      expect(p).toBe(store.state.declarations[0].meta.patterns[1])
+    })
+
+    it('updates a prop value', () => {
+      store.updatePropValue('foo', 'foo pattern 1', 'a', 'updated')
+      expect(store.state.declarations[0].meta.patterns[0].props.a).toBe(
+        'updated'
+      )
+    })
+
+    it('updates a data value', () => {
+      store.updateDataValue('foo', 'foo pattern 2', 'b', 1000)
+      expect(store.state.declarations[0].meta.patterns[1].data.b).toBe(1000)
+    })
+  })
+})

--- a/packages/@birdseye/vue/src/instrument.ts
+++ b/packages/@birdseye/vue/src/instrument.ts
@@ -146,22 +146,28 @@ export function createInstrument(
                 : inferValueFromType(meta.type)
           })
           return filled
+        },
+
+        // We need to clone data to collectly track some dependent value is changed
+        clonedData(): Record<string, any> {
+          return { ...this.data }
         }
       },
 
       watch: {
-        filledProps(newProps: Record<string, any>): void {
-          root.props = newProps
+        filledProps: {
+          handler(newProps: Record<string, any>): void {
+            root.props = newProps
+          },
+          immediate: true
         },
 
-        data(newData: Record<string, any>): void {
-          root.data = newData
+        clonedData: {
+          handler(newData: Record<string, any>): void {
+            root.data = newData
+          },
+          immediate: true
         }
-      },
-
-      created() {
-        root.props = this.filledProps
-        root.data = this.data
       },
 
       mounted() {

--- a/packages/@birdseye/vue/src/instrument.ts
+++ b/packages/@birdseye/vue/src/instrument.ts
@@ -148,7 +148,7 @@ export function createInstrument(
           return filled
         },
 
-        // We need to clone data to collectly track some dependent value is changed
+        // We need to clone data to correctly track some dependent value is changed
         clonedData(): Record<string, any> {
           return { ...this.data }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11607,9 +11607,9 @@ vue-jest@^2.6.0:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
-vue-lazy-components-option@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/vue-lazy-components-option/-/vue-lazy-components-option-0.1.0.tgz#acc5bff6115fdebfdf829366157f1251dedc8341"
+vue-lazy-components-option@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/vue-lazy-components-option/-/vue-lazy-components-option-0.1.1.tgz#b09409cda1e8c786c74a6be9871cf1863e8010b5"
 
 vue-loader@^15.2.1:
   version "15.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11607,6 +11607,10 @@ vue-jest@^2.6.0:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
+vue-lazy-components-option@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vue-lazy-components-option/-/vue-lazy-components-option-0.1.0.tgz#acc5bff6115fdebfdf829366157f1251dedc8341"
+
 vue-loader@^15.2.1:
   version "15.2.6"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.2.6.tgz#4ad4e56a0ca1fd89ebc4220f9e3bd4723097b397"


### PR DESCRIPTION
ref #2 

This PR allows us to edit props and data on components in addition show its values.

It is not fully implemented yet. For example, we cannot edit object property names nor add root level data.

I've added a light-weight store instance to manage the changes for props and data value. If it will be complicated in the future, we may use Vuex or other store libs.