### PR TITLE
feat: add mapRender option for catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ export default catalogFor(MyButton, 'MyButton').add('white button', {
 
 The above example makes the preview background color black. You can specify any CSS properties in `containerStyle` option.
 
+#### Wrapping catalog component with another element
+
+You can use `mapRender` option to modify rendered element structure. `mapRender` should be a function that receives [`createElement` function](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) and original VNode object as arguments respectively.
+
+The following example maps the catalog component with `VApp` component of [Vuetify](https://vuetifyjs.com).
+
+```js
+import { catalogFor } from '@birdseye/vue'
+import { VApp } from 'vuetify/lib'
+import MyButton from '@/components/MyButton.vue'
+
+export default catalogFor(MyButton, {
+  name: 'MyButton',
+
+  // Define map function to render
+  mapRender: (h, vnode) => {
+    return h(VApp, [vnode])
+  }
+}).add('white button', {
+  props: {
+    white: true
+  },
+  slots: {
+    default: 'Button Text'
+  }
+})
+```
+
 #### Writing catalog in SFC
 
 Update the webpack config in `vue.config.js`:

--- a/packages/@birdseye/vue/src/catalog.ts
+++ b/packages/@birdseye/vue/src/catalog.ts
@@ -1,4 +1,4 @@
-import Vue, { Component, VNode, ComponentOptions } from 'vue'
+import Vue, { Component, VNode, ComponentOptions, CreateElement } from 'vue'
 import { compileToFunctions } from 'vue-template-compiler'
 import { Catalog as BaseCatalog, ComponentPattern } from '@birdseye/core'
 import { createInstrument } from './instrument'
@@ -12,6 +12,7 @@ export interface CatalogOptions {
   name: string
   rootVue?: typeof Vue
   rootOptions?: ComponentOptions<Vue>
+  mapRender?: (this: Vue, h: CreateElement, wrapped: VNode) => VNode
 }
 
 export interface CatalogPatternOptions {
@@ -31,7 +32,8 @@ export function catalogFor(
 
   const { wrap } = createInstrument(
     options.rootVue || Vue,
-    options.rootOptions || {}
+    options.rootOptions || {},
+    options.mapRender
   )
 
   const Wrapper = wrap(Comp)

--- a/packages/@birdseye/vue/test/wrap.spec.ts
+++ b/packages/@birdseye/vue/test/wrap.spec.ts
@@ -293,6 +293,45 @@ describe('Wrap', () => {
     expect(wrapper.text()).toBe('injected')
   })
 
+  it('allows to map render function', async () => {
+    const { wrap } = createInstrument(Vue, {}, (h, vnode) => {
+      return h('div', { attrs: { 'data-test': 'wrapper' } }, [vnode])
+    })
+
+    const Test = Vue.extend({
+      props: ['foo'],
+
+      data() {
+        return {
+          bar: 123
+        }
+      },
+
+      render(h): VNode {
+        return h('div', [`foo: ${this.foo}, bar: ${this.bar}`])
+      }
+    })
+
+    const Wrapper = wrap(Test)
+
+    const wrapper = shallowMount(Wrapper, {
+      propsData: {
+        props: {
+          foo: 'Test'
+        },
+        data: {
+          bar: 456
+        }
+      }
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).toMatchInlineSnapshot(
+      `"<div data-test=\\"wrapper\\"><div style=\\"height: 100%;\\"><div>foo: Test, bar: 456</div></div></div>"`
+    )
+  })
+
   describe('props default', () => {
     async function test(
       meta: { type: ComponentDataType[]; defaultValue?: any },


### PR DESCRIPTION
There is a use case that we want to wrap catalog component with another element/component.

One is usage in Vuetify component. As Vuetify component need to have `VApp` component in ancestors, we need a way to inject it into our rendered catalog.

To deal with it, I've added `mapRender` option in `createInstrument` and `catalogFor`.