### PR TITLE
feat: remove height style from container element

### DIFF
--- a/packages/@birdseye/app/src/Preview.vue
+++ b/packages/@birdseye/app/src/Preview.vue
@@ -48,7 +48,6 @@ export default Vue.extend({
     const containerStyle: Partial<CSSStyleDeclaration> = {
       boxSizing: 'border-box',
       padding: '20px',
-      height: '100%',
       ...(pattern ? pattern.containerStyle : {})
     }
 

--- a/packages/@birdseye/app/tests/dummy/components/Fill.vue
+++ b/packages/@birdseye/app/tests/dummy/components/Fill.vue
@@ -26,4 +26,5 @@ patterns:
   - name: style
     containerStyle:
       backgroundColor: "#aaa"
+      height: 100%
 </birdseye>


### PR DESCRIPTION
BREAKING CHANGE: preview container element no longer has height: 100%; style. You need to manually add it via containerStyles option if needed