### PR TITLE
fix: remount wrapper component when catalog route is changed

### DIFF
--- a/packages/@birdseye/app/src/Preview.vue
+++ b/packages/@birdseye/app/src/Preview.vue
@@ -38,6 +38,7 @@ export default Vue.extend({
 
     const pattern = this.store.getPattern(this.meta, this.pattern)
     const data = {
+      key: this.meta + '/' + this.pattern,
       props: {
         props: pattern ? pattern.props : {},
         data: pattern ? pattern.data : {}


### PR DESCRIPTION
In the current behavior, wrapper component is reused when a catalog route is changed. This causes component animation and it can be a problem if the users are doing visual regression testing as snapshots can be different because of animation.

This PR makes wrapper component always remounted in that case, so that such animation will not happen.