### PR TITLE
feat: support scoped slot of catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,47 @@ export default catalogFor(MyButton, 'MyButton').add('white button', {
 
 The above example makes the preview background color black. You can specify any CSS properties in `containerStyle` option.
 
+#### Injecting slots and scoped slots
+
+You can inject slots and scoped slots by using `slots` option of `add` function. Pass a template string for a slot:
+
+```js
+import { catalogFor } from '@birdseye/vue'
+import MyButton from '@/components/MyButton.vue'
+
+export default catalogFor(MyButton, 'MyButton')
+  .add('primary', {
+    props: {
+      primary: true
+    },
+    slots: {
+      // Directly pass template string for the slot
+      default: '<span>Button Text</span>'
+    }
+  })
+```
+
+Pass a function for a scoped slot. The first argument is injected scoped slot props. You can get `$createElement` helper via `this` context:
+
+```js
+import { catalogFor } from '@birdseye/vue'
+import MyButton from '@/components/MyButton.vue'
+
+export default catalogFor(MyButton, 'MyButton')
+  .add('primary', {
+    props: {
+      primary: true
+    },
+    slots: {
+      // Pass scoped slot function
+      default(props) {
+        const h = this.$createElement
+        return h('span', ['Button Text ', props.message])
+      }
+    }
+  })
+```
+
 #### Wrapping catalog component with another element
 
 You can use `mapRender` option to modify rendered element structure. `mapRender` should be a function that receives [`createElement` function](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) and original VNode object as arguments respectively.

--- a/packages/@birdseye/app/tests/dummy/catalogs/ScopedSlot.catalog.ts
+++ b/packages/@birdseye/app/tests/dummy/catalogs/ScopedSlot.catalog.ts
@@ -1,0 +1,39 @@
+import Vue from 'vue'
+import { catalogFor } from '@birdseye/vue'
+import ScopedSlot from './ScopedSlot.vue'
+
+const Another = Vue.extend({
+  props: {
+    message: {
+      type: String,
+      required: true,
+    },
+  },
+
+  render(h: Function) {
+    return h('strong', { style: 'font-weight: bold; color: #ff0000;' }, [
+      this.message,
+    ])
+  },
+})
+
+export default catalogFor(ScopedSlot, 'ScopedSlot')
+  .add('inject scoped slot', {
+    slots: {
+      default(props: any) {
+        return [this.$createElement('div', ['message: ', props.message])]
+      },
+    },
+  })
+  .add('use another component for slot', {
+    slots: {
+      default(props: any) {
+        const h = this.$createElement
+        return [
+          h('div', ['Top']),
+          h(Another, { props: { message: props.message } }),
+          h('div', ['Bottom']),
+        ]
+      },
+    },
+  })

--- a/packages/@birdseye/app/tests/dummy/catalogs/ScopedSlot.vue
+++ b/packages/@birdseye/app/tests/dummy/catalogs/ScopedSlot.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <slot message="Hello" />
+  </div>
+</template>

--- a/packages/@birdseye/core/src/interfaces.ts
+++ b/packages/@birdseye/core/src/interfaces.ts
@@ -34,7 +34,7 @@ export interface ComponentPattern {
   name: string
   props: Record<string, any>
   data: Record<string, any>
-  slots: Record<string, (props: any) => VNode[]>
+  slots: Record<string, (props: any) => VNode[] | undefined>
   containerStyle: Partial<CSSStyleDeclaration>
   plugins: PluginOptions
 }

--- a/packages/@birdseye/vue/test/wrap.spec.ts
+++ b/packages/@birdseye/vue/test/wrap.spec.ts
@@ -39,8 +39,8 @@ describe('Wrap', () => {
         el('baz', this.baz),
 
         // slots
-        el('default-slot', this.$slots.default),
-        el('named-slot', this.$slots.named),
+        el('default-slot', this.$scopedSlots.default?.({ message: 'Hello' })),
+        el('named-slot', this.$scopedSlots.named?.({ message: 'Hello' })),
       ])
     },
   })
@@ -75,9 +75,9 @@ describe('Wrap', () => {
         },
         data: {},
       },
-      slots: {
-        default: 'default slot',
-        named: 'named slot',
+      scopedSlots: {
+        default: '<div>default slot</div>',
+        named: '<div>named slot</div>',
       },
     })
 
@@ -85,6 +85,32 @@ describe('Wrap', () => {
 
     expect(wrapper.find('#default-slot').text()).toBe('default slot')
     expect(wrapper.find('#named-slot').text()).toBe('named slot')
+  })
+
+  it('applies initial scoped slots', async () => {
+    const wrapper = shallowMount(Wrapper, {
+      propsData: {
+        props: {
+          foo: '',
+        },
+        data: {},
+      },
+      scopedSlots: {
+        default(props: any): any {
+          const h = this.$createElement
+          return h('div', ['default: ', props.message])
+        },
+        named(props: any): any {
+          const h = this.$createElement
+          return h('div', ['named: ', props.message])
+        },
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('#default-slot').text()).toBe('default: Hello')
+    expect(wrapper.find('#named-slot').text()).toBe('named: Hello')
   })
 
   it('updates props', async () => {


### PR DESCRIPTION
Supporting to inject scoped slots for catalog component.
This also unlocks the usage of another component in catalog slots which the users can directly specify a component to `$createElement`.