### PR TITLE
build: ignore dependabot commit on netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,4 @@
 publish = "packages/@birdseye/app/dist"
 command = "yarn build && yarn catalog"
 environment = { NODE_ENV = "development" }
+ignore = "git log -1 --pretty=%B | grep dependabot"


### PR DESCRIPTION
ref https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/

As dependabot uses most of my Netlify build minutes, ignoring dependabot commits is needed to save money.