### PR TITLE
feat(snapshot): add skip option

### DIFF
--- a/packages/@birdseye/snapshot/README.md
+++ b/packages/@birdseye/snapshot/README.md
@@ -101,6 +101,7 @@ All options should be into `plugins.snapshot` for each catalog settings.
 
 Available snapshot options are below:
 
+- `skip` Set `true` if you want to skip capturing for the catalog. (default `false`)
 - `target` CSS selector for the element that will be captured. (default: the root element of the preview)
 - `delay` A delay (ms) before taking snapshot.
 - `disableCssAnimation` Disable CSS animations and transitions if `true`. (default `true`)

--- a/packages/@birdseye/snapshot/src/index.ts
+++ b/packages/@birdseye/snapshot/src/index.ts
@@ -38,9 +38,10 @@ export async function snapshot(options: SnapshotOptions): Promise<void> {
   await page.goto(opts.url)
 
   // Get all snapshot options from catalogs.
-  const routes: CatalogRoute[] = await page.evaluate(() => {
+  const rawRoutes: CatalogRoute[] = await page.evaluate(() => {
     return window.__birdseye_routes__
   })
+  const routes = rawRoutes.filter((route) => !route.snapshot?.skip)
 
   await browser.close()
 

--- a/packages/@birdseye/snapshot/src/plugin.ts
+++ b/packages/@birdseye/snapshot/src/plugin.ts
@@ -2,6 +2,7 @@ import { Catalog } from '@birdseye/core'
 import { PageContext } from './page-context'
 
 export interface SnapshotOptions {
+  skip?: boolean
   target?: string
   delay?: number
   disableCssAnimation?: boolean

--- a/packages/@birdseye/snapshot/test/fixture/catalogs/Animation.catalog.ts
+++ b/packages/@birdseye/snapshot/test/fixture/catalogs/Animation.catalog.ts
@@ -1,10 +1,21 @@
 import { catalogFor } from '@birdseye/vue'
 import Animation from '../components/Animation.vue'
 
-export default catalogFor(Animation, 'Animation').add('Normal', {
-  plugins: {
-    snapshot: {
-      delay: 1000,
+export default catalogFor(Animation, 'Animation')
+  .add('Normal', {
+    plugins: {
+      snapshot: {
+        delay: 1000,
+      },
     },
-  },
-})
+  })
+  .add('Blink', {
+    props: {
+      blink: true,
+    },
+    plugins: {
+      snapshot: {
+        skip: true,
+      },
+    },
+  })

--- a/packages/@birdseye/snapshot/test/fixture/components/Animation.vue
+++ b/packages/@birdseye/snapshot/test/fixture/components/Animation.vue
@@ -1,15 +1,21 @@
 <template>
-  <div ref="test" class="test"></div>
+  <div ref="test" class="test" :class="{ blink }"></div>
 </template>
 
 <script>
 export default {
   name: 'Animation',
 
+  props: {
+    blink: Boolean
+  },
+
   mounted() {
-    setTimeout(() => {
-      this.$refs.test.style.opacity = '1'
-    }, 1000)
+    if (!this.blink) {
+      setTimeout(() => {
+        this.$refs.test.style.opacity = '1'
+      }, 1000)
+    }
   }
 }
 </script>
@@ -20,5 +26,19 @@ export default {
   display: block;
   height: 30px;
   background-color: blue;
+}
+
+.test.blink {
+  animation: 1s ease-out infinite alternate blink !important;
+}
+
+@keyframes blink {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
 }
 </style>


### PR DESCRIPTION
There can be a catalog that we don't want to take a snapshot such as loading indicator.

To exclude such components from capture targets, adding `skip` option for the snapshot plugin.