### PR TITLE
fix(snapshot): make sure to capture when both skip and capture is specified

### DIFF
--- a/packages/@birdseye/snapshot/src/index.ts
+++ b/packages/@birdseye/snapshot/src/index.ts
@@ -38,10 +38,9 @@ export async function snapshot(options: SnapshotOptions): Promise<void> {
   await page.goto(opts.url)
 
   // Get all snapshot options from catalogs.
-  const rawRoutes: CatalogRoute[] = await page.evaluate(() => {
+  const routes: CatalogRoute[] = await page.evaluate(() => {
     return window.__birdseye_routes__
   })
-  const routes = rawRoutes.filter((route) => !route.snapshot?.skip)
 
   await browser.close()
 

--- a/packages/@birdseye/snapshot/src/plugin.ts
+++ b/packages/@birdseye/snapshot/src/plugin.ts
@@ -18,14 +18,18 @@ export function snapshotPlugin(catalogs: Catalog[]): void {
   const routes = catalogs.reduce<CatalogRoute[]>((acc, catalog) => {
     const meta = catalog.toDeclaration().meta
     return acc.concat(
-      meta.patterns.map((pattern) => {
-        return {
-          path: `/${encodeURIComponent(meta.name)}/${encodeURIComponent(
-            pattern.name
-          )}`,
-          snapshot: pattern.plugins.snapshot,
-        }
-      })
+      meta.patterns
+        .filter((pattern) => {
+          return !pattern.plugins.snapshot?.skip
+        })
+        .map((pattern) => {
+          return {
+            path: `/${encodeURIComponent(meta.name)}/${encodeURIComponent(
+              pattern.name
+            )}`,
+            snapshot: pattern.plugins.snapshot,
+          }
+        })
     )
   }, [])
 


### PR DESCRIPTION
If there are usages of `skip` and `capture` among different catalogs, some capture can be silently failed. This is because the catalog route data between in-browser and node.js is different as they are filtered only in node.js.