### PR TITLE
feat(snapshot): allow specifying capture target via the argument of capture function

### DIFF
--- a/packages/@birdseye/snapshot/package.json
+++ b/packages/@birdseye/snapshot/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@birdseye/core": "^0.6.0",
     "@birdseye/vue": "^0.6.0",
-    "capture-all": "^0.6.0",
+    "capture-all": "^0.7.0",
     "mkdirp": "^1.0.3",
     "puppeteer": "^5.2.0"
   }

--- a/packages/@birdseye/snapshot/src/plugin.ts
+++ b/packages/@birdseye/snapshot/src/plugin.ts
@@ -6,7 +6,10 @@ export interface SnapshotOptions {
   target?: string
   delay?: number
   disableCssAnimation?: boolean
-  capture?: (page: PageContext, capture: () => Promise<void>) => Promise<void>
+  capture?: (
+    page: PageContext,
+    capture: (target?: string) => Promise<void>
+  ) => Promise<void>
 }
 
 export interface CatalogRoute {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4577,10 +4577,10 @@ caniuse-lite@^1.0.30001109:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001114.tgz#2e88119afb332ead5eaa330e332e951b1c4bfea9"
   integrity sha512-ml/zTsfNBM+T1+mjglWRPgVsu2L76GAaADKX5f4t0pbhttEp0WMawJsHDYlFkVZkoA+89uvBRrVrEE4oqenzXQ==
 
-capture-all@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/capture-all/-/capture-all-0.6.0.tgz#f7d6c1381b91d67292c64f13c8925bf8d7135f2d"
-  integrity sha512-vCpEvY0AvolpmPrGUKtYxOzroz+evQvZoYPdPE5OYwamKTkSPg4vp4k4OQ6H9J5yCIUvUZ50GY9S9a1NAAIPgA==
+capture-all@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/capture-all/-/capture-all-0.7.0.tgz#22d9fa3c7e6cad37ab290c37aca9b12c33ebaefb"
+  integrity sha512-+qeD+605H6Hk290QuPH1hetbLu2aYSbkukxEI/WmxPp6On7JqkBBqPR53MTGIqTGSygbGQjTzKZORGyzWQkmCA==
   dependencies:
     puppeteer "^5.0.0"
 


### PR DESCRIPTION
The user will be able to specify the capture target via `capture` function's 1st argument.

```js
capture: async (page, capture) => {
  await page.click('.my-button')
  await capture('.part-a')
  await capture('.part-b')
}
```

